### PR TITLE
Remove VAN from bankAccount struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ by adding `circlex_api` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:circlex_api, "~> 0.1.7"}
+    {:circlex_api, "~> 0.1.8"}
   ]
 end
 ```

--- a/lib/circlex/api.ex
+++ b/lib/circlex/api.ex
@@ -11,7 +11,6 @@ defmodule Circlex.Api do
   @http_client Application.get_env(:circlex_api, :http_client, HTTPoison)
   def http_client(), do: @http_client
 
-
   defmodule Tooling do
     def not_implemented(), do: {:error, %{error: "Not implemented by Circlex client"}}
 

--- a/lib/circlex/api/core/bank_accounts.ex
+++ b/lib/circlex/api/core/bank_accounts.ex
@@ -32,8 +32,7 @@ defmodule Circlex.Api.Core.BankAccounts do
           id: "a033a6d8-05ae-11ed-9e62-6a1733211c00",
           status: "pending",
           tracking_ref: "CIR3KXZZ00",
-          update_date: "2022-07-17T08:59:41.344582Z",
-          virtual_account_number: "547425368404"
+          update_date: "2022-07-17T08:59:41.344582Z"
         }
       }
   """
@@ -77,8 +76,7 @@ defmodule Circlex.Api.Core.BankAccounts do
             id: "fce6d303-2923-43cf-a66a-1e4690e08d1b",
             status: "complete",
             tracking_ref: "CIR3KX3L99",
-            update_date: "2022-02-14T22:29:33.516Z",
-            virtual_account_number: "547425368404"
+            update_date: "2022-02-14T22:29:33.516Z"
           }
         ]
       }
@@ -109,8 +107,7 @@ defmodule Circlex.Api.Core.BankAccounts do
           id: "fce6d303-2923-43cf-a66a-1e4690e08d1b",
           status: "complete",
           tracking_ref: "CIR3KX3L99",
-          update_date: "2022-02-14T22:29:33.516Z",
-          virtual_account_number: "547425368404"
+          update_date: "2022-02-14T22:29:33.516Z"
         }
       }
   """
@@ -139,7 +136,7 @@ defmodule Circlex.Api.Core.BankAccounts do
             "name" => "CIRCLE INTERNET FINANCIAL INC"
           },
           beneficiary_bank: %Circlex.Struct.BeneficiaryBank{
-            account_number: "547425368404",
+            account_number: "198906493711",
             address: "1 MONEY STREET",
             city: "NEW YORK",
             country: "US",

--- a/lib/circlex/api/payments/bank_accounts.ex
+++ b/lib/circlex/api/payments/bank_accounts.ex
@@ -31,8 +31,7 @@ defmodule Circlex.Api.Payments.BankAccounts do
           id: "a033a6d8-05ae-11ed-9e62-6a1733211c00",
           status: "pending",
           tracking_ref: "CIR3KXZZ00",
-          update_date: "2022-07-17T08:59:41.344582Z",
-          virtual_account_number: "547425368404"
+          update_date: "2022-07-17T08:59:41.344582Z"
         }
       }
   """
@@ -76,8 +75,7 @@ defmodule Circlex.Api.Payments.BankAccounts do
             id: "fce6d303-2923-43cf-a66a-1e4690e08d1b",
             status: "complete",
             tracking_ref: "CIR3KX3L99",
-            update_date: "2022-02-14T22:29:33.516Z",
-            virtual_account_number: "547425368404"
+            update_date: "2022-02-14T22:29:33.516Z"
           }
         ]
       }
@@ -108,8 +106,7 @@ defmodule Circlex.Api.Payments.BankAccounts do
           id: "fce6d303-2923-43cf-a66a-1e4690e08d1b",
           status: "complete",
           tracking_ref: "CIR3KX3L99",
-          update_date: "2022-02-14T22:29:33.516Z",
-          virtual_account_number: "547425368404"
+          update_date: "2022-02-14T22:29:33.516Z"
         }
       }
   """

--- a/lib/circlex/api/payouts/bank_accounts.ex
+++ b/lib/circlex/api/payouts/bank_accounts.ex
@@ -31,8 +31,7 @@ defmodule Circlex.Api.Payouts.BankAccounts do
           id: "a033a6d8-05ae-11ed-9e62-6a1733211c00",
           status: "pending",
           tracking_ref: "CIR3KXZZ00",
-          update_date: "2022-07-17T08:59:41.344582Z",
-          virtual_account_number: "547425368404"
+          update_date: "2022-07-17T08:59:41.344582Z"
         }
       }
   """
@@ -75,8 +74,7 @@ defmodule Circlex.Api.Payouts.BankAccounts do
           id: "fce6d303-2923-43cf-a66a-1e4690e08d1b",
           status: "complete",
           tracking_ref: "CIR3KX3L99",
-          update_date: "2022-02-14T22:29:33.516Z",
-          virtual_account_number: "547425368404"
+          update_date: "2022-02-14T22:29:33.516Z"
         }
       }
   """

--- a/lib/circlex/emulator/api/core/bank_accounts_api.ex
+++ b/lib/circlex/emulator/api/core/bank_accounts_api.ex
@@ -27,7 +27,7 @@ defmodule Circlex.Emulator.Api.Core.BankAccountsApi do
   @route "/wires/:bank_account_id/instructions"
   def get_wire_instructions(%{bank_account_id: bank_account_id}) do
     with {:ok, bank_account} <- BankAccountState.get_bank_account(bank_account_id) do
-      {:ok, WireInstructions.serialize_bank_account(bank_account)}
+      {:ok, WireInstructions.from_bank_account(bank_account)}
     end
   end
 

--- a/lib/circlex/emulator/state.ex
+++ b/lib/circlex/emulator/state.ex
@@ -243,9 +243,6 @@ defmodule Circlex.Emulator.State do
   defp generate_type(:external_ref),
     do: "EXTREF" <> to_string(System.unique_integer([:positive]))
 
-  defp generate_type(:virtual_account_number),
-    do: Enum.random(100_000_000_000..999_999_999_999) |> to_string()
-
   defp serialize_st(st) do
     st
     |> WalletState.serialize()

--- a/lib/circlex/emulator/state/bank_account_state.ex
+++ b/lib/circlex/emulator/state/bank_account_state.ex
@@ -48,8 +48,7 @@ defmodule Circlex.Emulator.State.BankAccountState do
        billing_details: billing_details,
        bank_address: bank_address,
        create_date: State.next(:date),
-       update_date: State.next(:date),
-       virtual_account_number: State.next(:virtual_account_number)
+       update_date: State.next(:date)
      }}
   end
 

--- a/lib/circlex/struct/bank_account.ex
+++ b/lib/circlex/struct/bank_account.ex
@@ -10,8 +10,7 @@ defmodule Circlex.Struct.BankAccount do
     :billing_details,
     :bank_address,
     :create_date,
-    :update_date,
-    :virtual_account_number
+    :update_date
   ]
 
   def deserialize(bank_account) do
@@ -24,8 +23,7 @@ defmodule Circlex.Struct.BankAccount do
       billing_details: fetch(bank_account, :billingDetails),
       bank_address: fetch(bank_account, :bankAddress),
       create_date: fetch(bank_account, :createDate),
-      update_date: fetch(bank_account, :updateDate),
-      virtual_account_number: fetch(bank_account, :virtualAccountNumber)
+      update_date: fetch(bank_account, :updateDate)
     }
   end
 
@@ -39,8 +37,7 @@ defmodule Circlex.Struct.BankAccount do
       billingDetails: bank_account.billing_details,
       bankAddress: bank_account.bank_address,
       createDate: bank_account.create_date,
-      updateDate: bank_account.update_date,
-      virtualAccountNumber: bank_account.virtual_account_number
+      updateDate: bank_account.update_date
     }
   end
 end

--- a/lib/circlex/struct/wire_instructions.ex
+++ b/lib/circlex/struct/wire_instructions.ex
@@ -21,11 +21,11 @@ defmodule Circlex.Struct.WireInstructions do
 
   # Constructs wire instructions from a bank account given its id and tracking_ref
   def from_bank_account(bank_account = %Circlex.Struct.BankAccount{}) do
-    <<virtualAccountNumber::binary-size(12)>> <> _rest =
+    <<virtual_account_number::binary-size(12)>> <> _rest =
       :binary.decode_unsigned(bank_account.id) |> Integer.to_string()
 
     beneficiary_bank = %{
-      account_number: virtualAccountNumber,
+      account_number: virtual_account_number,
       address: "1 MONEY STREET",
       city: "NEW YORK",
       country: "US",

--- a/lib/circlex/struct/wire_instructions.ex
+++ b/lib/circlex/struct/wire_instructions.ex
@@ -19,10 +19,13 @@ defmodule Circlex.Struct.WireInstructions do
     }
   end
 
-  # Takes a BankAccount for serializing
-  def serialize_bank_account(bank_account = %Circlex.Struct.BankAccount{}) do
+  # Constructs wire instructions from a bank account given its id and tracking_ref
+  def from_bank_account(bank_account = %Circlex.Struct.BankAccount{}) do
+    <<virtualAccountNumber::binary-size(12)>> <> _rest =
+      :binary.decode_unsigned(bank_account.id) |> Integer.to_string()
+
     beneficiary_bank = %{
-      account_number: bank_account.virtual_account_number,
+      account_number: virtualAccountNumber,
       address: "1 MONEY STREET",
       city: "NEW YORK",
       country: "US",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Circlex.MixProject do
   def project do
     [
       app: :circlex_api,
-      version: "0.1.7",
+      version: "0.1.8",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/circlex/emulator/api/core/bank_accounts_api_test.exs
+++ b/test/circlex/emulator/api/core/bank_accounts_api_test.exs
@@ -29,8 +29,7 @@ defmodule Circlex.Emulator.Api.Core.BankAccountsApiTest do
               id: "a033a6d8-05ae-11ed-9e62-6a1733211c00",
               status: "pending",
               trackingRef: "CIR3KXZZ00",
-              updateDate: "2022-07-17T08:59:41.344582Z",
-              virtualAccountNumber: "547425368404"
+              updateDate: "2022-07-17T08:59:41.344582Z"
             }} ==
              BankAccountsApi.create_bank_account(%{
                idempotencyKey: UUID.uuid1(),
@@ -75,8 +74,7 @@ defmodule Circlex.Emulator.Api.Core.BankAccountsApiTest do
                 id: "fce6d303-2923-43cf-a66a-1e4690e08d1b",
                 status: "complete",
                 trackingRef: "CIR3KX3L99",
-                updateDate: "2022-02-14T22:29:33.516Z",
-                virtualAccountNumber: "547425368404"
+                updateDate: "2022-02-14T22:29:33.516Z"
               }
             ]} == BankAccountsApi.list_bank_accounts(%{})
   end
@@ -99,8 +97,7 @@ defmodule Circlex.Emulator.Api.Core.BankAccountsApiTest do
               id: "fce6d303-2923-43cf-a66a-1e4690e08d1b",
               status: "complete",
               trackingRef: "CIR3KX3L99",
-              updateDate: "2022-02-14T22:29:33.516Z",
-              virtualAccountNumber: "547425368404"
+              updateDate: "2022-02-14T22:29:33.516Z"
             }} ==
              BankAccountsApi.get_bank_account(%{
                bank_account_id: "fce6d303-2923-43cf-a66a-1e4690e08d1b"
@@ -116,7 +113,7 @@ defmodule Circlex.Emulator.Api.Core.BankAccountsApiTest do
                 name: "CIRCLE INTERNET FINANCIAL INC"
               },
               beneficiaryBank: %{
-                accountNumber: "547425368404",
+                accountNumber: "198906493711",
                 address: "1 MONEY STREET",
                 city: "NEW YORK",
                 country: "US",

--- a/test/circlex/emulator/logic/bank_account_logic_test.exs
+++ b/test/circlex/emulator/logic/bank_account_logic_test.exs
@@ -20,8 +20,7 @@ defmodule Circlex.Emulator.Logic.BankAccountLogicTest do
     id: "fce6d303-2923-43cf-a66a-1e4690e08d1b",
     status: "complete",
     tracking_ref: "CIR3KX3L99",
-    update_date: "2022-02-14T22:29:33.516Z",
-    virtual_account_number: "547425368404"
+    update_date: "2022-02-14T22:29:33.516Z"
   }
 
   setup do

--- a/test/circlex/emulator/state/bank_account_state_test.exs
+++ b/test/circlex/emulator/state/bank_account_state_test.exs
@@ -21,8 +21,7 @@ defmodule Circlex.Emulator.State.BankAccountStateTest do
     id: "fce6d303-2923-43cf-a66a-1e4690e08d1b",
     status: "complete",
     tracking_ref: "CIR3KX3L99",
-    update_date: "2022-02-14T22:29:33.516Z",
-    virtual_account_number: "547425368404"
+    update_date: "2022-02-14T22:29:33.516Z"
   }
 
   setup do

--- a/test/circlex/struct/beneficiary_bank_test.exs
+++ b/test/circlex/struct/beneficiary_bank_test.exs
@@ -3,7 +3,7 @@ defmodule Circlex.Struct.BeneficiaryBankTest do
   alias Circlex.Struct.BeneficiaryBank
 
   @beneficiary_bank %BeneficiaryBank{
-    account_number: "547425368404",
+    account_number: "198906493711",
     address: "1 MONEY STREET",
     city: "NEW YORK",
     country: "US",
@@ -15,7 +15,7 @@ defmodule Circlex.Struct.BeneficiaryBankTest do
   }
 
   @beneficiary_bank_ser %{
-    accountNumber: "547425368404",
+    accountNumber: "198906493711",
     address: "1 MONEY STREET",
     city: "NEW YORK",
     country: "US",

--- a/test/circlex/struct/wire_instructions_test.exs
+++ b/test/circlex/struct/wire_instructions_test.exs
@@ -9,7 +9,7 @@ defmodule Circlex.Struct.WireInstructionsTest do
       name: "CIRCLE INTERNET FINANCIAL INC"
     },
     beneficiary_bank: %BeneficiaryBank{
-      account_number: "547425368404",
+      account_number: "198906493711",
       address: "1 MONEY STREET",
       city: "NEW YORK",
       country: "US",
@@ -43,8 +43,7 @@ defmodule Circlex.Struct.WireInstructionsTest do
       country: "CA"
     },
     create_date: "2022-02-14T22:29:32.779Z",
-    update_date: "2022-02-14T22:29:33.516Z",
-    virtual_account_number: "547425368404"
+    update_date: "2022-02-14T22:29:33.516Z"
   }
 
   @wire_instructions_ser %{
@@ -54,7 +53,7 @@ defmodule Circlex.Struct.WireInstructionsTest do
       name: "CIRCLE INTERNET FINANCIAL INC"
     },
     beneficiaryBank: %{
-      accountNumber: "547425368404",
+      accountNumber: "198906493711",
       address: "1 MONEY STREET",
       city: "NEW YORK",
       country: "US",
@@ -74,9 +73,9 @@ defmodule Circlex.Struct.WireInstructionsTest do
     end
   end
 
-  describe "serialize" do
+  describe "construct" do
     test "success" do
-      assert WireInstructions.serialize_bank_account(@bank_account) == @wire_instructions_ser
+      assert WireInstructions.from_bank_account(@bank_account) == @wire_instructions_ser
     end
   end
 end

--- a/test/support/initial_state.json
+++ b/test/support/initial_state.json
@@ -22,8 +22,7 @@
         "country": "CA"
       },
       "createDate": "2022-02-14T22:29:32.779Z",
-      "updateDate": "2022-02-14T22:29:33.516Z",
-      "virtualAccountNumber": "547425368404"
+      "updateDate": "2022-02-14T22:29:33.516Z"
     }
   ],
   "wallets": [

--- a/test/support/test.ex
+++ b/test/support/test.ex
@@ -28,8 +28,7 @@ defmodule Circlex.Test do
              80>>,
            <<138, 188, 117, 102, 29, 10, 220, 76, 146, 255, 224, 189, 147, 170, 123, 117, 245,
              233, 203, 54, 29, 173, 66, 196, 169, 148, 65, 232, 223, 235, 76, 223>>}
-        ],
-        virtual_account_number: ["547425368404"]
+        ]
       })
 
     [port: port, initial_state: initial_state, state_name: state_name, next: next]


### PR DESCRIPTION
Talked to Coburn and realized I incorrectly added a `virtual_account_number` field in the `bank_account` struct. VAN is now deterministically calculated on-the-fly using the below formula instead of being stored separately in a bank account object.

calculation:
```
# e.g. id: "fce6d303-2923-43cf-a66a-1e4690e08d1b" --> virtualAccountNumber: "198906493711"
 <<virtualAccountNumber::binary-size(12)>> <> _rest = :binary.decode_unsigned(bank_account.id) |> Integer.to_string()
```