### PR TITLE
Add Publish on Release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aryanbhasin @coburncoburn @hayesgm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+jobs:
+  create-release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache Build
+        uses: actions/cache@v3
+        with:
+          path: _build
+          key: ${{ runner.os }}-build
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "25.0"
+          elixir-version: "1.13.4"
+
+      - name: Elixir Dependencies
+        run: mix deps.get
+
+      - name: Mix Compile
+        run: mix compile
+
+      - name: Run Tests
+        run: mix test
+
+      - name: Publish to Hex
+        uses: synchronal/hex-publish-action@v1
+        with:
+          name: circlex_api
+          key: ${{ secrets.HEX_PM_KEY }}


### PR DESCRIPTION
This patch adds a new Github Action which automatically publishes to Hex when a new release is created (e.g. a tagged version). This will be useful for automatically being able to deploy code that is merged into main.